### PR TITLE
revert information provider browser instead of addons

### DIFF
--- a/xml/Settings.xml
+++ b/xml/Settings.xml
@@ -120,9 +120,9 @@
             <icon>icons/Pictures.png</icon>
           </item>
           <item>
-            <label>$LOCALIZE[21412]</label>
-            <onclick>ActivateWindow(informationproviderbrowser)</onclick>
-            <icon>icons/Metadata.png</icon>
+            <label>$LOCALIZE[24001]</label>
+            <onclick>ActivateWindow(addonbrowser)</onclick>
+            <icon>icons/Addons.png</icon>
           </item>
           <item>
             <label>$LOCALIZE[2]</label>


### PR DESCRIPTION
Because we now support python addons, and will be adding several, we need to be able to access them for enable/disable. So revert direct vector to information providers